### PR TITLE
deprecate android api lower 6.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,13 +31,13 @@ android {
 }
 
 dependencies {
-    implementation 'com.android.support:appcompat-v7:25.3.1'
-//    implementation 'com.android.support:support-annotations:28.0.0'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'com.github.evotor:push-notifications:v0.2.1'
-    implementation 'com.github.evotor:query-api:1.0.0'
-    implementation 'com.google.code.gson:gson:2.8.5'
-    testImplementation 'junit:junit:4.12'
+    compile 'com.android.support:appcompat-v7:25.3.1'
+//    compile 'com.android.support:support-annotations:28.0.0'
+    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    compile 'com.github.evotor:push-notifications:v0.2.1'
+    compile 'com.github.evotor:query-api:1.0.0'
+    compile 'com.google.code.gson:gson:2.8.5'
+    testCompile 'junit:junit:4.12'
 }
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ android {
     compileSdkVersion 25
     buildToolsVersion "25.0.3"
     defaultConfig {
-        minSdkVersion 22
+        minSdkVersion 23
         targetSdkVersion 25
         versionCode version
         versionName "0.4.5"
@@ -31,12 +31,13 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:appcompat-v7:25.3.1'
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    compile 'com.github.evotor:push-notifications:v0.2.1'
-    compile 'com.github.evotor:query-api:1.0.0'
-    compile 'com.google.code.gson:gson:2.8.5'
-    testCompile 'junit:junit:4.12'
+    implementation 'com.android.support:appcompat-v7:25.3.1'
+//    implementation 'com.android.support:support-annotations:28.0.0'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation 'com.github.evotor:push-notifications:v0.2.1'
+    implementation 'com.github.evotor:query-api:1.0.0'
+    implementation 'com.google.code.gson:gson:2.8.5'
+    testImplementation 'junit:junit:4.12'
 }
 
 repositories {

--- a/src/main/java/ru/evotor/framework/component/viewdata/IntegrationComponentViewDataApi.kt
+++ b/src/main/java/ru/evotor/framework/component/viewdata/IntegrationComponentViewDataApi.kt
@@ -6,7 +6,6 @@ import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import android.content.pm.ResolveInfo
 import android.os.Bundle
-import android.support.v4.content.ContextCompat
 import ru.evotor.framework.ColorUtils
 import ru.evotor.framework.component.PaymentPerformer
 import ru.evotor.framework.core.action.event.receipt.payment.system.event.PaymentSystemEvent
@@ -71,7 +70,7 @@ object IntegrationComponentViewDataApi {
         val backgroundColor =  if (metaData.containsKey(BACKGROUND_COLOR_KEY))
             metaData.getInt(BACKGROUND_COLOR_KEY)
         else
-            ContextCompat.getColor(context, R.color.white)
+            context.getColor(R.color.white)
         return PaymentPerformerViewData(
                 paymentPerformer,
                 resolveInfo.loadIcon(packageManager),

--- a/src/main/java/ru/evotor/framework/core/IntegrationAppCompatActivity.java
+++ b/src/main/java/ru/evotor/framework/core/IntegrationAppCompatActivity.java
@@ -6,6 +6,7 @@ import android.support.v7.app.AppCompatActivity;
 
 import ru.evotor.IBundlable;
 
+@Deprecated // 23.09.2019
 public abstract class IntegrationAppCompatActivity extends AppCompatActivity {
 
     private IntegrationResponse mIntegrationResponse = null;


### PR DESCRIPTION
support android api version 23 (6.0)
support of android api version below 23 (5.x and lower) is deprecated