### PR TITLE
STDEV-5035 updated gradle-wrapper to 6.1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,6 @@ android {
         versionCode version
         versionName "0.4.9"
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
-
         resValue "integer", "versionCodeIntegrationLibrary", "$version"
     }
     buildTypes {
@@ -114,14 +113,13 @@ task javadocJar(type: Jar, dependsOn: dokka) {
 
 publishing {
     publications {
-
         mavenKotlin(MavenPublication) {
             groupId 'com.github.evotor'
             artifactId "integration-library"
-            version "MRK-166"
+            version "STDEV-5035"
             artifact(sourceJar)
             artifact(javadocJar)
-            artifact "${project.buildDir}/outputs/aar/${project.archivesBaseName}-release.aar"
+            artifact "${project.buildDir}/outputs/aar/${project.archivesBaseName}.aar"
 
             //generate pom nodes for dependencies
             pom.withXml {

--- a/build.gradle
+++ b/build.gradle
@@ -3,8 +3,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 apply plugin: 'maven-publish'
-// TODO
-// apply plugin: 'org.jetbrains.dokka-android'
+apply plugin: 'org.jetbrains.dokka-android'
 
 android {
     def version = 15
@@ -60,8 +59,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        // TODO
-        // classpath "org.jetbrains.dokka:dokka-android-gradle-plugin:0.9.18"
+        classpath "org.jetbrains.dokka:dokka-android-gradle-plugin:0.9.18"
     }
 }
 // in the individual module build.gradle files
@@ -73,39 +71,35 @@ allprojects {
     }
 }
 
-// TODO
-/*dokka {
+dokka {
     moduleName = 'integration-library'
     outputFormat = 'javadoc'
     outputDirectory = "$buildDir/javadoc"
 
     includes = ['packages.md']
 
-}*/
+}
 
-// TODO
-/*task dokkaJavadoc(type: org.jetbrains.dokka.gradle.DokkaTask) {
+task dokkaJavadoc(type: org.jetbrains.dokka.gradle.DokkaTask) {
     outputFormat = "javadoc"
     outputDirectory = "$buildDir/dokkaJavadoc"
 
     includes = ['packages.md']
-}*/
+}
 
-// TODO
-/*task dokkaHTMLAsJava(type: org.jetbrains.dokka.gradle.DokkaTask) {
+task dokkaHTMLAsJava(type: org.jetbrains.dokka.gradle.DokkaTask) {
     outputFormat = "html-as-java"
     outputDirectory = "$buildDir/dokkaHtmlasjava"
 
     includes = ['packages.md']
-}*/
+}
 
-// TODO
-/*task dokkaHTML(type: org.jetbrains.dokka.gradle.DokkaTask) {
+task dokkaHTML(type: org.jetbrains.dokka.gradle.DokkaTask) {
     outputFormat = "html"
     outputDirectory = "$buildDir/dokkaHtml"
 
     includes = ['packages.md']
-}*/
+}
 
 task sourceJar(type: Jar) {
     classifier "sources"
@@ -113,11 +107,10 @@ task sourceJar(type: Jar) {
 }
 
 // build a jar with javadoc
-// TODO
-/*task javadocJar(type: Jar, dependsOn: dokka) {
+task javadocJar(type: Jar, dependsOn: dokka) {
     classifier = 'javadoc'
     from dokka.outputDirectory
-}*/
+}
 
 publishing {
     publications {
@@ -127,8 +120,7 @@ publishing {
             artifactId "integration-library"
             version "MRK-166"
             artifact(sourceJar)
-            // TODO
-            // artifact(javadocJar)
+            artifact(javadocJar)
             artifact "${project.buildDir}/outputs/aar/${project.archivesBaseName}-release.aar"
 
             //generate pom nodes for dependencies

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,8 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 apply plugin: 'maven-publish'
-apply plugin: 'org.jetbrains.dokka-android'
+// TODO
+// apply plugin: 'org.jetbrains.dokka-android'
 
 android {
     def version = 15
@@ -59,7 +60,8 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "org.jetbrains.dokka:dokka-android-gradle-plugin:0.9.18"
+        // TODO
+        // classpath "org.jetbrains.dokka:dokka-android-gradle-plugin:0.9.18"
     }
 }
 // in the individual module build.gradle files
@@ -71,35 +73,39 @@ allprojects {
     }
 }
 
-dokka {
+// TODO
+/*dokka {
     moduleName = 'integration-library'
     outputFormat = 'javadoc'
     outputDirectory = "$buildDir/javadoc"
 
     includes = ['packages.md']
 
-}
+}*/
 
-task dokkaJavadoc(type: org.jetbrains.dokka.gradle.DokkaTask) {
+// TODO
+/*task dokkaJavadoc(type: org.jetbrains.dokka.gradle.DokkaTask) {
     outputFormat = "javadoc"
     outputDirectory = "$buildDir/dokkaJavadoc"
 
     includes = ['packages.md']
-}
+}*/
 
-task dokkaHTMLAsJava(type: org.jetbrains.dokka.gradle.DokkaTask) {
+// TODO
+/*task dokkaHTMLAsJava(type: org.jetbrains.dokka.gradle.DokkaTask) {
     outputFormat = "html-as-java"
     outputDirectory = "$buildDir/dokkaHtmlasjava"
 
     includes = ['packages.md']
-}
+}*/
 
-task dokkaHTML(type: org.jetbrains.dokka.gradle.DokkaTask) {
+// TODO
+/*task dokkaHTML(type: org.jetbrains.dokka.gradle.DokkaTask) {
     outputFormat = "html"
     outputDirectory = "$buildDir/dokkaHtml"
 
     includes = ['packages.md']
-}
+}*/
 
 task sourceJar(type: Jar) {
     classifier "sources"
@@ -107,10 +113,11 @@ task sourceJar(type: Jar) {
 }
 
 // build a jar with javadoc
-task javadocJar(type: Jar, dependsOn: dokka) {
+// TODO
+/*task javadocJar(type: Jar, dependsOn: dokka) {
     classifier = 'javadoc'
     from dokka.outputDirectory
-}
+}*/
 
 publishing {
     publications {
@@ -120,7 +127,8 @@ publishing {
             artifactId "integration-library"
             version "MRK-166"
             artifact(sourceJar)
-            artifact(javadocJar)
+            // TODO
+            // artifact(javadocJar)
             artifact "${project.buildDir}/outputs/aar/${project.archivesBaseName}-release.aar"
 
             //generate pom nodes for dependencies

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'androidx.annotation:annotation:1.1.0'
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:1.4.21"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:1.4.31"
 
     implementation 'com.github.evotor:push-notifications:v0.2.1'
     implementation 'com.github.evotor:query-api:1.0.0'
@@ -50,13 +50,13 @@ repositories {
 }
 
 buildscript {
-    ext.kotlin_version = '1.4.21'
+    ext.kotlin_version = '1.4.31'
     repositories {
         jcenter()
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:4.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "org.jetbrains.dokka:dokka-android-gradle-plugin:0.9.18"
     }
@@ -119,7 +119,7 @@ publishing {
             version "STDEV-5035"
             artifact(sourceJar)
             artifact(javadocJar)
-            artifact "${project.buildDir}/outputs/aar/${project.archivesBaseName}.aar"
+            artifact "${project.buildDir}/outputs/aar/${project.archivesBaseName}-release.aar"
 
             //generate pom nodes for dependencies
             pom.withXml {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,16 @@
+# Project-wide Gradle settings.
+# IDE (e.g. Android Studio) users:
+# Gradle settings configured through the IDE *will override*
+# any settings specified in this file.
+# For more details on how to configure your build environment visit
+# http://www.gradle.org/docs/current/userguide/build_environment.html
+# Specifies the JVM arguments used for the daemon process.
+# The setting is particularly useful for tweaking memory settings.
+# Default value: -Xmx10248m -XX:MaxPermSize=256m
+# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+# When configured, Gradle will run in incubating parallel mode.
+# This option should only be used with decoupled projects. More details, visit
+# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
+# org.gradle.parallel=true
+android.enableJetifier=true
+android.useAndroidX=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Dec 11 13:24:36 MSK 2018
+#Wed Mar 10 15:59:09 MSK 2021
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip


### PR DESCRIPTION
fixes build error: "The current Gradle version 4.6 is not compatible with the Kotlin Gradle plugin"