### PR TITLE
STDEV-18791 Дополнительный реквизит чека коррекции (тег 1192)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'maven-publish'
 apply plugin: 'org.jetbrains.dokka'
 
 android {
-    def version = 29
+    def version = 28
 
     compileSdk 29
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ apply plugin: 'maven-publish'
 apply plugin: 'org.jetbrains.dokka'
 
 android {
-    def version = 28
+    def version = 29
 
     compileSdk 29
 

--- a/src/main/java/ru/evotor/framework/core/action/command/open_receipt_command/OpenCorrectionIncomeReceiptCommand.kt
+++ b/src/main/java/ru/evotor/framework/core/action/command/open_receipt_command/OpenCorrectionIncomeReceiptCommand.kt
@@ -37,7 +37,7 @@ class OpenCorrectionIncomeReceiptCommand(
     val correctionType: CorrectionType,
     @FiscalRequisite(tag = FiscalTags.PRESCRIPTION_NUMBER)
     val prescription: String? = null,
-    @FiscalRequisite(tag = FiscalTags.FISCAL_SIGN_OF_INCORRECT_RECIEPT)
+    @FiscalRequisite(tag = FiscalTags.ADDITIONAL_REQUISITE_1192)
     val fiscalSignOfIncorrectReceipt: String? = null,
     val setPurchaserContactData: SetPurchaserContactData? = null
 ) : IBundlable {

--- a/src/main/java/ru/evotor/framework/core/action/command/open_receipt_command/OpenCorrectionIncomeReceiptCommand.kt
+++ b/src/main/java/ru/evotor/framework/core/action/command/open_receipt_command/OpenCorrectionIncomeReceiptCommand.kt
@@ -25,6 +25,7 @@ import java.util.*
  * @param correctionDate Дата совершения корректируемого расчета (ТЕГ 1178)
  * @param correctionType Тип коррекции (ТЕГ 1173)
  * @param prescription Номер предписания налогового органа (ТЕГ 1179)
+ * @param fiscalSignOfIncorrectReceipt Фискальный признак ошибочного чека (ТЕГ 1192)
  * @param setPurchaserContactData Контактные данные покупателя, на которые будет отправлен чек
  */
 class OpenCorrectionIncomeReceiptCommand(
@@ -36,6 +37,8 @@ class OpenCorrectionIncomeReceiptCommand(
     val correctionType: CorrectionType,
     @FiscalRequisite(tag = FiscalTags.PRESCRIPTION_NUMBER)
     val prescription: String? = null,
+    @FiscalRequisite(tag = FiscalTags.FISCAL_SIGN_OF_INCORRECT_RECIEPT)
+    val fiscalSignOfIncorrectReceipt: String? = null,
     val setPurchaserContactData: SetPurchaserContactData? = null
 ) : IBundlable {
 
@@ -46,6 +49,7 @@ class OpenCorrectionIncomeReceiptCommand(
         private const val KEY_CORRECTION_DATE = "correctionDate"
         private const val KEY_CORRECTION_TYPE = "correctionType"
         private const val KEY_PRESCRIPTION = "prescription"
+        private const val KEY_FISCAL_SIGN_OF_INCORRECT_RECEIPT = "fiscalSignOfIncorrectReceipt"
         private const val KEY_RECEIPT_SET_PURCHASER_CONTACT_DATA = "setPurchaserContactData"
 
         @JvmStatic
@@ -63,6 +67,7 @@ class OpenCorrectionIncomeReceiptCommand(
                     correctionDate = Date(it.getLong(KEY_CORRECTION_DATE)),
                     correctionType = CorrectionType.valueOf(it.getString(KEY_CORRECTION_TYPE) as String),
                     prescription = it.getString(KEY_PRESCRIPTION),
+                    fiscalSignOfIncorrectReceipt = it.getString(KEY_FISCAL_SIGN_OF_INCORRECT_RECEIPT),
                     setPurchaserContactData = SetPurchaserContactData.from(
                         it.getBundle(
                             KEY_RECEIPT_SET_PURCHASER_CONTACT_DATA
@@ -96,6 +101,7 @@ class OpenCorrectionIncomeReceiptCommand(
             putLong(KEY_CORRECTION_DATE, correctionDate.time)
             putString(KEY_CORRECTION_TYPE, correctionType.name)
             putString(KEY_PRESCRIPTION, prescription)
+            putString(KEY_FISCAL_SIGN_OF_INCORRECT_RECEIPT, fiscalSignOfIncorrectReceipt)
             putBundle(
                 KEY_RECEIPT_SET_PURCHASER_CONTACT_DATA,
                 setPurchaserContactData?.toBundle()

--- a/src/main/java/ru/evotor/framework/core/action/command/open_receipt_command/OpenCorrectionOutcomeReceiptCommand.kt
+++ b/src/main/java/ru/evotor/framework/core/action/command/open_receipt_command/OpenCorrectionOutcomeReceiptCommand.kt
@@ -37,7 +37,7 @@ class OpenCorrectionOutcomeReceiptCommand(
     val correctionType: CorrectionType,
     @FiscalRequisite(tag = FiscalTags.PRESCRIPTION_NUMBER)
     val prescription: String? = null,
-    @FiscalRequisite(tag = FiscalTags.FISCAL_SIGN_OF_INCORRECT_RECIEPT)
+    @FiscalRequisite(tag = FiscalTags.ADDITIONAL_REQUISITE_1192)
     val fiscalSignOfIncorrectReceipt: String? = null,
     val setPurchaserContactData: SetPurchaserContactData? = null
 ) : IBundlable {

--- a/src/main/java/ru/evotor/framework/core/action/command/open_receipt_command/OpenCorrectionOutcomeReceiptCommand.kt
+++ b/src/main/java/ru/evotor/framework/core/action/command/open_receipt_command/OpenCorrectionOutcomeReceiptCommand.kt
@@ -25,6 +25,7 @@ import java.util.*
  * @param correctionDate Дата совершения корректируемого расчета (ТЕГ 1178)
  * @param correctionType Тип коррекции (ТЕГ 1173)
  * @param prescription Номер предписания налогового органа (ТЕГ 1179)
+ * @param fiscalSignOfIncorrectReceipt Фискальный признак ошибочного чека (ТЕГ 1192)
  * @param setPurchaserContactData Контактные данные покупателя, на которые будет отправлен чек
  */
 class OpenCorrectionOutcomeReceiptCommand(
@@ -36,6 +37,8 @@ class OpenCorrectionOutcomeReceiptCommand(
     val correctionType: CorrectionType,
     @FiscalRequisite(tag = FiscalTags.PRESCRIPTION_NUMBER)
     val prescription: String? = null,
+    @FiscalRequisite(tag = FiscalTags.FISCAL_SIGN_OF_INCORRECT_RECIEPT)
+    val fiscalSignOfIncorrectReceipt: String? = null,
     val setPurchaserContactData: SetPurchaserContactData? = null
 ) : IBundlable {
 
@@ -46,6 +49,7 @@ class OpenCorrectionOutcomeReceiptCommand(
         private const val KEY_CORRECTION_DATE = "correctionDate"
         private const val KEY_CORRECTION_TYPE = "correctionType"
         private const val KEY_PRESCRIPTION = "prescription"
+        private const val KEY_FISCAL_SIGN_OF_INCORRECT_RECEIPT = "fiscalSignOfIncorrectReceipt"
         private const val KEY_RECEIPT_SET_PURCHASER_CONTACT_DATA = "setPurchaserContactData"
 
         @JvmStatic
@@ -63,6 +67,7 @@ class OpenCorrectionOutcomeReceiptCommand(
                     correctionDate = Date(it.getLong(KEY_CORRECTION_DATE)),
                     correctionType = CorrectionType.valueOf(it.getString(KEY_CORRECTION_TYPE) as String),
                     prescription = it.getString(KEY_PRESCRIPTION),
+                    fiscalSignOfIncorrectReceipt = it.getString(KEY_FISCAL_SIGN_OF_INCORRECT_RECEIPT),
                     setPurchaserContactData = SetPurchaserContactData.from(
                         it.getBundle(
                             KEY_RECEIPT_SET_PURCHASER_CONTACT_DATA
@@ -96,6 +101,7 @@ class OpenCorrectionOutcomeReceiptCommand(
             putLong(KEY_CORRECTION_DATE, correctionDate.time)
             putString(KEY_CORRECTION_TYPE, correctionType.name)
             putString(KEY_PRESCRIPTION, prescription)
+            putString(KEY_FISCAL_SIGN_OF_INCORRECT_RECEIPT, fiscalSignOfIncorrectReceipt)
             putBundle(
                 KEY_RECEIPT_SET_PURCHASER_CONTACT_DATA,
                 setPurchaserContactData?.toBundle()

--- a/src/main/java/ru/evotor/framework/core/action/command/open_receipt_command/OpenCorrectionReturnIncomeReceiptCommand.kt
+++ b/src/main/java/ru/evotor/framework/core/action/command/open_receipt_command/OpenCorrectionReturnIncomeReceiptCommand.kt
@@ -37,7 +37,7 @@ class OpenCorrectionReturnIncomeReceiptCommand(
     val correctionType: CorrectionType,
     @FiscalRequisite(tag = FiscalTags.PRESCRIPTION_NUMBER)
     val prescription: String? = null,
-    @FiscalRequisite(tag = FiscalTags.FISCAL_SIGN_OF_INCORRECT_RECIEPT)
+    @FiscalRequisite(tag = FiscalTags.ADDITIONAL_REQUISITE_1192)
     val fiscalSignOfIncorrectReceipt: String? = null,
     val setPurchaserContactData: SetPurchaserContactData? = null
 ) : IBundlable {

--- a/src/main/java/ru/evotor/framework/core/action/command/open_receipt_command/OpenCorrectionReturnIncomeReceiptCommand.kt
+++ b/src/main/java/ru/evotor/framework/core/action/command/open_receipt_command/OpenCorrectionReturnIncomeReceiptCommand.kt
@@ -25,6 +25,7 @@ import java.util.*
  * @param correctionDate Дата совершения корректируемого расчета (ТЕГ 1178)
  * @param correctionType Тип коррекции (ТЕГ 1173)
  * @param prescription Номер предписания налогового органа (ТЕГ 1179)
+ * @param fiscalSignOfIncorrectReceipt Фискальный признак ошибочного чека (ТЕГ 1192)
  * @param setPurchaserContactData Контактные данные покупателя, на которые будет отправлен чек
  */
 class OpenCorrectionReturnIncomeReceiptCommand(
@@ -36,6 +37,8 @@ class OpenCorrectionReturnIncomeReceiptCommand(
     val correctionType: CorrectionType,
     @FiscalRequisite(tag = FiscalTags.PRESCRIPTION_NUMBER)
     val prescription: String? = null,
+    @FiscalRequisite(tag = FiscalTags.FISCAL_SIGN_OF_INCORRECT_RECIEPT)
+    val fiscalSignOfIncorrectReceipt: String? = null,
     val setPurchaserContactData: SetPurchaserContactData? = null
 ) : IBundlable {
 
@@ -46,6 +49,7 @@ class OpenCorrectionReturnIncomeReceiptCommand(
         private const val KEY_CORRECTION_DATE = "correctionDate"
         private const val KEY_CORRECTION_TYPE = "correctionType"
         private const val KEY_PRESCRIPTION = "prescription"
+        private const val KEY_FISCAL_SIGN_OF_INCORRECT_RECEIPT = "fiscalSignOfIncorrectReceipt"
         private const val KEY_RECEIPT_SET_PURCHASER_CONTACT_DATA = "setPurchaserContactData"
 
         @JvmStatic
@@ -63,6 +67,7 @@ class OpenCorrectionReturnIncomeReceiptCommand(
                     correctionDate = Date(it.getLong(KEY_CORRECTION_DATE)),
                     correctionType = CorrectionType.valueOf(it.getString(KEY_CORRECTION_TYPE) as String),
                     prescription = it.getString(KEY_PRESCRIPTION),
+                    fiscalSignOfIncorrectReceipt = it.getString(KEY_FISCAL_SIGN_OF_INCORRECT_RECEIPT),
                     setPurchaserContactData = SetPurchaserContactData.from(
                         it.getBundle(
                             KEY_RECEIPT_SET_PURCHASER_CONTACT_DATA
@@ -96,6 +101,7 @@ class OpenCorrectionReturnIncomeReceiptCommand(
             putLong(KEY_CORRECTION_DATE, correctionDate.time)
             putString(KEY_CORRECTION_TYPE, correctionType.name)
             putString(KEY_PRESCRIPTION, prescription)
+            putString(KEY_FISCAL_SIGN_OF_INCORRECT_RECEIPT, fiscalSignOfIncorrectReceipt)
             putBundle(
                 KEY_RECEIPT_SET_PURCHASER_CONTACT_DATA,
                 setPurchaserContactData?.toBundle()

--- a/src/main/java/ru/evotor/framework/core/action/command/open_receipt_command/OpenCorrectionReturnOutcomeReceiptCommand.kt
+++ b/src/main/java/ru/evotor/framework/core/action/command/open_receipt_command/OpenCorrectionReturnOutcomeReceiptCommand.kt
@@ -25,6 +25,7 @@ import java.util.*
  * @param correctionDate Дата совершения корректируемого расчета (ТЕГ 1178)
  * @param correctionType Тип коррекции (ТЕГ 1173)
  * @param prescription Номер предписания налогового органа (ТЕГ 1179)
+ * @param fiscalSignOfIncorrectReceipt Фискальный признак ошибочного чека (ТЕГ 1192)
  * @param setPurchaserContactData Контактные данные покупателя, на которые будет отправлен чек
  */
 class OpenCorrectionReturnOutcomeReceiptCommand(
@@ -36,6 +37,8 @@ class OpenCorrectionReturnOutcomeReceiptCommand(
     val correctionType: CorrectionType,
     @FiscalRequisite(tag = FiscalTags.PRESCRIPTION_NUMBER)
     val prescription: String? = null,
+    @FiscalRequisite(tag = FiscalTags.FISCAL_SIGN_OF_INCORRECT_RECIEPT)
+    val fiscalSignOfIncorrectReceipt: String? = null,
     val setPurchaserContactData: SetPurchaserContactData? = null
 ) : IBundlable {
 
@@ -46,6 +49,7 @@ class OpenCorrectionReturnOutcomeReceiptCommand(
         private const val KEY_CORRECTION_DATE = "correctionDate"
         private const val KEY_CORRECTION_TYPE = "correctionType"
         private const val KEY_PRESCRIPTION = "prescription"
+        private const val KEY_FISCAL_SIGN_OF_INCORRECT_RECEIPT = "fiscalSignOfIncorrectReceipt"
         private const val KEY_RECEIPT_SET_PURCHASER_CONTACT_DATA = "setPurchaserContactData"
 
         @JvmStatic
@@ -63,6 +67,7 @@ class OpenCorrectionReturnOutcomeReceiptCommand(
                     correctionDate = Date(it.getLong(KEY_CORRECTION_DATE)),
                     correctionType = CorrectionType.valueOf(it.getString(KEY_CORRECTION_TYPE) as String),
                     prescription = it.getString(KEY_PRESCRIPTION),
+                    fiscalSignOfIncorrectReceipt = it.getString(KEY_FISCAL_SIGN_OF_INCORRECT_RECEIPT),
                     setPurchaserContactData = SetPurchaserContactData.from(
                         it.getBundle(
                             KEY_RECEIPT_SET_PURCHASER_CONTACT_DATA
@@ -96,6 +101,7 @@ class OpenCorrectionReturnOutcomeReceiptCommand(
             putLong(KEY_CORRECTION_DATE, correctionDate.time)
             putString(KEY_CORRECTION_TYPE, correctionType.name)
             putString(KEY_PRESCRIPTION, prescription)
+            putString(KEY_FISCAL_SIGN_OF_INCORRECT_RECEIPT, fiscalSignOfIncorrectReceipt)
             putBundle(
                 KEY_RECEIPT_SET_PURCHASER_CONTACT_DATA,
                 setPurchaserContactData?.toBundle()

--- a/src/main/java/ru/evotor/framework/core/action/command/open_receipt_command/OpenCorrectionReturnOutcomeReceiptCommand.kt
+++ b/src/main/java/ru/evotor/framework/core/action/command/open_receipt_command/OpenCorrectionReturnOutcomeReceiptCommand.kt
@@ -37,7 +37,7 @@ class OpenCorrectionReturnOutcomeReceiptCommand(
     val correctionType: CorrectionType,
     @FiscalRequisite(tag = FiscalTags.PRESCRIPTION_NUMBER)
     val prescription: String? = null,
-    @FiscalRequisite(tag = FiscalTags.FISCAL_SIGN_OF_INCORRECT_RECIEPT)
+    @FiscalRequisite(tag = FiscalTags.ADDITIONAL_REQUISITE_1192)
     val fiscalSignOfIncorrectReceipt: String? = null,
     val setPurchaserContactData: SetPurchaserContactData? = null
 ) : IBundlable {

--- a/src/main/java/ru/evotor/framework/core/action/command/print_receipt_command/PrintCorrectionIncomeReceiptCommand.kt
+++ b/src/main/java/ru/evotor/framework/core/action/command/print_receipt_command/PrintCorrectionIncomeReceiptCommand.kt
@@ -47,7 +47,7 @@ class PrintCorrectionIncomeReceiptCommand(
     val correctionType: CorrectionType,
     @FiscalRequisite(tag = FiscalTags.PRESCRIPTION_NUMBER)
     val prescription: String? = null,
-    @FiscalRequisite(tag = FiscalTags.FISCAL_SIGN_OF_INCORRECT_RECIEPT)
+    @FiscalRequisite(tag = FiscalTags.ADDITIONAL_REQUISITE_1192)
     val fiscalSignOfIncorrectReceipt: String? = null,
 ) : IBundlable {
 

--- a/src/main/java/ru/evotor/framework/core/action/command/print_receipt_command/PrintCorrectionIncomeReceiptCommand.kt
+++ b/src/main/java/ru/evotor/framework/core/action/command/print_receipt_command/PrintCorrectionIncomeReceiptCommand.kt
@@ -1,7 +1,6 @@
 package ru.evotor.framework.core.action.command.print_receipt_command
 
 import android.content.Context
-import android.content.Intent
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -31,6 +30,7 @@ import java.util.*
  * @param correctionDate Дата совершения корректируемого расчета (ТЕГ 1178)
  * @param correctionType Тип коррекции (ТЕГ 1173)
  * @param prescription Номер предписания налогового органа (ТЕГ 1179)
+ * @param fiscalSignOfIncorrectReceipt Фискальный признак ошибочного чека (ТЕГ 1192)
  */
 class PrintCorrectionIncomeReceiptCommand(
     val printReceipts: List<Receipt.PrintReceipt>,
@@ -46,7 +46,9 @@ class PrintCorrectionIncomeReceiptCommand(
     @FiscalRequisite(tag = FiscalTags.CORRECTION_TYPE)
     val correctionType: CorrectionType,
     @FiscalRequisite(tag = FiscalTags.PRESCRIPTION_NUMBER)
-    val prescription: String? = null
+    val prescription: String? = null,
+    @FiscalRequisite(tag = FiscalTags.FISCAL_SIGN_OF_INCORRECT_RECIEPT)
+    val fiscalSignOfIncorrectReceipt: String? = null,
 ) : IBundlable {
 
     fun process(context: Context, callback: IntegrationManagerCallback) {
@@ -69,12 +71,9 @@ class PrintCorrectionIncomeReceiptCommand(
         return Bundle().apply {
             putParcelableArrayList(
                 KEY_PRINT_RECEIPTS,
-                printReceipts.mapTo(
-                    ArrayList(),
-                    {
-                        PrintReceiptMapper.toBundle(it)
-                    }
-                )
+                printReceipts.mapTo(ArrayList()) {
+                    PrintReceiptMapper.toBundle(it)
+                }
             )
             putBundle(KEY_RECEIPT_EXTRA, extra?.toBundle())
             putString(KEY_CLIENT_EMAIL, clientEmail)
@@ -89,6 +88,7 @@ class PrintCorrectionIncomeReceiptCommand(
             putLong(KEY_CORRECTION_DATE, correctionDate.time)
             putString(KEY_CORRECTION_TYPE, correctionType.name)
             putString(KEY_PRESCRIPTION, prescription)
+            putString(KEY_FISCAL_SIGN_OF_INCORRECT_RECEIPT, fiscalSignOfIncorrectReceipt)
         }
     }
 
@@ -107,6 +107,7 @@ class PrintCorrectionIncomeReceiptCommand(
         private const val KEY_CORRECTION_DATE = "correctionDate"
         private const val KEY_CORRECTION_TYPE = "correctionType"
         private const val KEY_PRESCRIPTION = "prescription"
+        private const val KEY_FISCAL_SIGN_OF_INCORRECT_RECEIPT = "fiscalSignOfIncorrectReceipt"
 
         @JvmStatic
         fun create(bundle: Bundle?): PrintCorrectionIncomeReceiptCommand? {
@@ -122,7 +123,8 @@ class PrintCorrectionIncomeReceiptCommand(
                     userUuid = PrintReceiptCommand.getUserUuid(bundle),
                     correctionDate = Date(it.getLong(KEY_CORRECTION_DATE)),
                     correctionType = CorrectionType.valueOf(it.getString(KEY_CORRECTION_TYPE) as String),
-                    prescription = it.getString(KEY_PRESCRIPTION)
+                    prescription = it.getString(KEY_PRESCRIPTION),
+                    fiscalSignOfIncorrectReceipt = it.getString(KEY_FISCAL_SIGN_OF_INCORRECT_RECEIPT)
                 )
             }
         }

--- a/src/main/java/ru/evotor/framework/core/action/command/print_receipt_command/PrintCorrectionOutcomeReceiptCommand.kt
+++ b/src/main/java/ru/evotor/framework/core/action/command/print_receipt_command/PrintCorrectionOutcomeReceiptCommand.kt
@@ -30,6 +30,7 @@ import java.util.*
  * @param correctionDate Дата совершения корректируемого расчета (ТЕГ 1178)
  * @param correctionType Тип коррекции (ТЕГ 1173)
  * @param prescription Номер предписания налогового органа (ТЕГ 1179)
+ * @param fiscalSignOfIncorrectReceipt Фискальный признак ошибочного чека (ТЕГ 1192)
  */
 class PrintCorrectionOutcomeReceiptCommand(
     val printReceipts: List<Receipt.PrintReceipt>,
@@ -45,7 +46,9 @@ class PrintCorrectionOutcomeReceiptCommand(
     @FiscalRequisite(tag = FiscalTags.CORRECTION_TYPE)
     val correctionType: CorrectionType,
     @FiscalRequisite(tag = FiscalTags.PRESCRIPTION_NUMBER)
-    val prescription: String? = null
+    val prescription: String? = null,
+    @FiscalRequisite(tag = FiscalTags.FISCAL_SIGN_OF_INCORRECT_RECIEPT)
+    val fiscalSignOfIncorrectReceipt: String? = null,
 ) : IBundlable {
 
     fun process(context: Context, callback: IntegrationManagerCallback) {
@@ -68,12 +71,9 @@ class PrintCorrectionOutcomeReceiptCommand(
         return Bundle().apply {
             putParcelableArrayList(
                 KEY_PRINT_RECEIPTS,
-                printReceipts.mapTo(
-                    ArrayList(),
-                    {
-                        PrintReceiptMapper.toBundle(it)
-                    }
-                )
+                printReceipts.mapTo(ArrayList()) {
+                    PrintReceiptMapper.toBundle(it)
+                }
             )
             putBundle(KEY_RECEIPT_EXTRA, extra?.toBundle())
             putString(KEY_CLIENT_EMAIL, clientEmail)
@@ -88,6 +88,7 @@ class PrintCorrectionOutcomeReceiptCommand(
             putLong(KEY_CORRECTION_DATE, correctionDate.time)
             putString(KEY_CORRECTION_TYPE, correctionType.name)
             putString(KEY_PRESCRIPTION, prescription)
+            putString(KEY_FISCAL_SIGN_OF_INCORRECT_RECEIPT, fiscalSignOfIncorrectReceipt)
         }
     }
 
@@ -106,6 +107,7 @@ class PrintCorrectionOutcomeReceiptCommand(
         private const val KEY_CORRECTION_DATE = "correctionDate"
         private const val KEY_CORRECTION_TYPE = "correctionType"
         private const val KEY_PRESCRIPTION = "prescription"
+        private const val KEY_FISCAL_SIGN_OF_INCORRECT_RECEIPT = "fiscalSignOfIncorrectReceipt"
 
         @JvmStatic
         fun create(bundle: Bundle?): PrintCorrectionOutcomeReceiptCommand? {
@@ -121,7 +123,8 @@ class PrintCorrectionOutcomeReceiptCommand(
                     userUuid = PrintReceiptCommand.getUserUuid(bundle),
                     correctionDate = Date(it.getLong(KEY_CORRECTION_DATE)),
                     correctionType = CorrectionType.valueOf(it.getString(KEY_CORRECTION_TYPE) as String),
-                    prescription = it.getString(KEY_PRESCRIPTION)
+                    prescription = it.getString(KEY_PRESCRIPTION),
+                    fiscalSignOfIncorrectReceipt = it.getString(KEY_FISCAL_SIGN_OF_INCORRECT_RECEIPT)
                 )
             }
         }

--- a/src/main/java/ru/evotor/framework/core/action/command/print_receipt_command/PrintCorrectionOutcomeReceiptCommand.kt
+++ b/src/main/java/ru/evotor/framework/core/action/command/print_receipt_command/PrintCorrectionOutcomeReceiptCommand.kt
@@ -47,7 +47,7 @@ class PrintCorrectionOutcomeReceiptCommand(
     val correctionType: CorrectionType,
     @FiscalRequisite(tag = FiscalTags.PRESCRIPTION_NUMBER)
     val prescription: String? = null,
-    @FiscalRequisite(tag = FiscalTags.FISCAL_SIGN_OF_INCORRECT_RECIEPT)
+    @FiscalRequisite(tag = FiscalTags.ADDITIONAL_REQUISITE_1192)
     val fiscalSignOfIncorrectReceipt: String? = null,
 ) : IBundlable {
 

--- a/src/main/java/ru/evotor/framework/core/action/command/print_receipt_command/PrintCorrectionReturnIncomeReceiptCommand.kt
+++ b/src/main/java/ru/evotor/framework/core/action/command/print_receipt_command/PrintCorrectionReturnIncomeReceiptCommand.kt
@@ -1,13 +1,11 @@
 package ru.evotor.framework.core.action.command.print_receipt_command
 
 import android.content.Context
-import android.content.Intent
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
 import ru.evotor.IBundlable
 import ru.evotor.framework.core.ActivityStarter
-import ru.evotor.framework.core.ICanStartActivity
 import ru.evotor.framework.core.IntegrationManagerCallback
 import ru.evotor.framework.core.IntegrationManagerImpl
 import ru.evotor.framework.core.action.datamapper.PrintReceiptMapper
@@ -32,6 +30,7 @@ import java.util.*
  * @param correctionDate Дата совершения корректируемого расчета (ТЕГ 1178)
  * @param correctionType Тип коррекции (ТЕГ 1173)
  * @param prescription Номер предписания налогового органа (ТЕГ 1179)
+ * @param fiscalSignOfIncorrectReceipt Фискальный признак ошибочного чека (ТЕГ 1192)
  */
 class PrintCorrectionReturnIncomeReceiptCommand(
     val printReceipts: List<Receipt.PrintReceipt>,
@@ -47,7 +46,9 @@ class PrintCorrectionReturnIncomeReceiptCommand(
     @FiscalRequisite(tag = FiscalTags.CORRECTION_TYPE)
     val correctionType: CorrectionType,
     @FiscalRequisite(tag = FiscalTags.PRESCRIPTION_NUMBER)
-    val prescription: String? = null
+    val prescription: String? = null,
+    @FiscalRequisite(tag = FiscalTags.FISCAL_SIGN_OF_INCORRECT_RECIEPT)
+    val fiscalSignOfIncorrectReceipt: String? = null
 ) : IBundlable {
 
     fun process(context: Context, callback: IntegrationManagerCallback) {
@@ -70,12 +71,9 @@ class PrintCorrectionReturnIncomeReceiptCommand(
         return Bundle().apply {
             putParcelableArrayList(
                 KEY_PRINT_RECEIPTS,
-                printReceipts.mapTo(
-                    ArrayList(),
-                    {
-                        PrintReceiptMapper.toBundle(it)
-                    }
-                )
+                printReceipts.mapTo(ArrayList()) {
+                    PrintReceiptMapper.toBundle(it)
+                }
             )
             putBundle(KEY_RECEIPT_EXTRA, extra?.toBundle())
             putString(KEY_CLIENT_EMAIL, clientEmail)
@@ -90,6 +88,7 @@ class PrintCorrectionReturnIncomeReceiptCommand(
             putLong(KEY_CORRECTION_DATE, correctionDate.time)
             putString(KEY_CORRECTION_TYPE, correctionType.name)
             putString(KEY_PRESCRIPTION, prescription)
+            putString(KEY_FISCAL_SIGN_OF_INCORRECT_RECEIPT, fiscalSignOfIncorrectReceipt)
         }
     }
 
@@ -108,6 +107,7 @@ class PrintCorrectionReturnIncomeReceiptCommand(
         private const val KEY_CORRECTION_DATE = "correctionDate"
         private const val KEY_CORRECTION_TYPE = "correctionType"
         private const val KEY_PRESCRIPTION = "prescription"
+        private const val KEY_FISCAL_SIGN_OF_INCORRECT_RECEIPT = "fiscalSignOfIncorrectReceipt"
 
         @JvmStatic
         fun create(bundle: Bundle?): PrintCorrectionReturnIncomeReceiptCommand? {
@@ -123,7 +123,8 @@ class PrintCorrectionReturnIncomeReceiptCommand(
                     userUuid = PrintReceiptCommand.getUserUuid(bundle),
                     correctionDate = Date(it.getLong(KEY_CORRECTION_DATE)),
                     correctionType = CorrectionType.valueOf(it.getString(KEY_CORRECTION_TYPE) as String),
-                    prescription = it.getString(KEY_PRESCRIPTION)
+                    prescription = it.getString(KEY_PRESCRIPTION),
+                    fiscalSignOfIncorrectReceipt = it.getString(KEY_FISCAL_SIGN_OF_INCORRECT_RECEIPT)
                 )
             }
         }

--- a/src/main/java/ru/evotor/framework/core/action/command/print_receipt_command/PrintCorrectionReturnIncomeReceiptCommand.kt
+++ b/src/main/java/ru/evotor/framework/core/action/command/print_receipt_command/PrintCorrectionReturnIncomeReceiptCommand.kt
@@ -47,7 +47,7 @@ class PrintCorrectionReturnIncomeReceiptCommand(
     val correctionType: CorrectionType,
     @FiscalRequisite(tag = FiscalTags.PRESCRIPTION_NUMBER)
     val prescription: String? = null,
-    @FiscalRequisite(tag = FiscalTags.FISCAL_SIGN_OF_INCORRECT_RECIEPT)
+    @FiscalRequisite(tag = FiscalTags.ADDITIONAL_REQUISITE_1192)
     val fiscalSignOfIncorrectReceipt: String? = null
 ) : IBundlable {
 

--- a/src/main/java/ru/evotor/framework/core/action/command/print_receipt_command/PrintCorrectionReturnOutcomeReceiptCommand.kt
+++ b/src/main/java/ru/evotor/framework/core/action/command/print_receipt_command/PrintCorrectionReturnOutcomeReceiptCommand.kt
@@ -1,7 +1,6 @@
 package ru.evotor.framework.core.action.command.print_receipt_command
 
 import android.content.Context
-import android.content.Intent
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
@@ -31,6 +30,7 @@ import java.util.*
  * @param correctionDate Дата совершения корректируемого расчета (ТЕГ 1178)
  * @param correctionType Тип коррекции (ТЕГ 1173)
  * @param prescription Номер предписания налогового органа (ТЕГ 1179)
+ * @param fiscalSignOfIncorrectReceipt Фискальный признак ошибочного чека (ТЕГ 1192)
  */
 class PrintCorrectionReturnOutcomeReceiptCommand(
     val printReceipts: List<Receipt.PrintReceipt>,
@@ -46,7 +46,9 @@ class PrintCorrectionReturnOutcomeReceiptCommand(
     @FiscalRequisite(tag = FiscalTags.CORRECTION_TYPE)
     val correctionType: CorrectionType,
     @FiscalRequisite(tag = FiscalTags.PRESCRIPTION_NUMBER)
-    val prescription: String? = null
+    val prescription: String? = null,
+    @FiscalRequisite(tag = FiscalTags.FISCAL_SIGN_OF_INCORRECT_RECIEPT)
+    val fiscalSignOfIncorrectReceipt: String? = null
 ) : IBundlable {
 
     fun process(context: Context, callback: IntegrationManagerCallback) {
@@ -69,12 +71,9 @@ class PrintCorrectionReturnOutcomeReceiptCommand(
         return Bundle().apply {
             putParcelableArrayList(
                 KEY_PRINT_RECEIPTS,
-                printReceipts.mapTo(
-                    ArrayList(),
-                    {
-                        PrintReceiptMapper.toBundle(it)
-                    }
-                )
+                printReceipts.mapTo(ArrayList()) {
+                    PrintReceiptMapper.toBundle(it)
+                }
             )
             putBundle(KEY_RECEIPT_EXTRA, extra?.toBundle())
             putString(KEY_CLIENT_EMAIL, clientEmail)
@@ -89,6 +88,7 @@ class PrintCorrectionReturnOutcomeReceiptCommand(
             putLong(KEY_CORRECTION_DATE, correctionDate.time)
             putString(KEY_CORRECTION_TYPE, correctionType.name)
             putString(KEY_PRESCRIPTION, prescription)
+            putString(KEY_FISCAL_SIGN_OF_INCORRECT_RECEIPT, fiscalSignOfIncorrectReceipt)
         }
     }
 
@@ -107,6 +107,7 @@ class PrintCorrectionReturnOutcomeReceiptCommand(
         private const val KEY_CORRECTION_DATE = "correctionDate"
         private const val KEY_CORRECTION_TYPE = "correctionType"
         private const val KEY_PRESCRIPTION = "prescription"
+        private const val KEY_FISCAL_SIGN_OF_INCORRECT_RECEIPT = "fiscalSignOfIncorrectReceipt"
 
         @JvmStatic
         fun create(bundle: Bundle?): PrintCorrectionReturnOutcomeReceiptCommand? {
@@ -122,7 +123,8 @@ class PrintCorrectionReturnOutcomeReceiptCommand(
                     userUuid = PrintReceiptCommand.getUserUuid(bundle),
                     correctionDate = Date(it.getLong(KEY_CORRECTION_DATE)),
                     correctionType = CorrectionType.valueOf(it.getString(KEY_CORRECTION_TYPE) as String),
-                    prescription = it.getString(KEY_PRESCRIPTION)
+                    prescription = it.getString(KEY_PRESCRIPTION),
+                    fiscalSignOfIncorrectReceipt = it.getString(KEY_FISCAL_SIGN_OF_INCORRECT_RECEIPT)
                 )
             }
         }

--- a/src/main/java/ru/evotor/framework/core/action/command/print_receipt_command/PrintCorrectionReturnOutcomeReceiptCommand.kt
+++ b/src/main/java/ru/evotor/framework/core/action/command/print_receipt_command/PrintCorrectionReturnOutcomeReceiptCommand.kt
@@ -47,7 +47,7 @@ class PrintCorrectionReturnOutcomeReceiptCommand(
     val correctionType: CorrectionType,
     @FiscalRequisite(tag = FiscalTags.PRESCRIPTION_NUMBER)
     val prescription: String? = null,
-    @FiscalRequisite(tag = FiscalTags.FISCAL_SIGN_OF_INCORRECT_RECIEPT)
+    @FiscalRequisite(tag = FiscalTags.ADDITIONAL_REQUISITE_1192)
     val fiscalSignOfIncorrectReceipt: String? = null
 ) : IBundlable {
 

--- a/src/main/java/ru/evotor/framework/core/action/command/print_receipt_command/PrintReceiptCommandResult.java
+++ b/src/main/java/ru/evotor/framework/core/action/command/print_receipt_command/PrintReceiptCommandResult.java
@@ -68,6 +68,11 @@ public class PrintReceiptCommandResult implements IBundlable {
      */
     public static final int ERROR_CODE_PREVIOUS_DOCUMENT_NOT_PRINTED = -13;
 
+    /**
+     * Дополнительный реквизит чека коррекции (тег 1192) не является unsigned int
+     */
+    public static final int ERROR_CODE_INVALID_FISCAL_SIGN_OF_INCORRECT_RECEIPT = -14;
+
     @Nullable
     public static PrintReceiptCommandResult create(@Nullable Bundle bundle) {
         if (bundle == null) {

--- a/src/main/java/ru/evotor/framework/core/action/command/print_receipt_command/PrintReceiptCommandResult.java
+++ b/src/main/java/ru/evotor/framework/core/action/command/print_receipt_command/PrintReceiptCommandResult.java
@@ -69,7 +69,8 @@ public class PrintReceiptCommandResult implements IBundlable {
     public static final int ERROR_CODE_PREVIOUS_DOCUMENT_NOT_PRINTED = -13;
 
     /**
-     * Дополнительный реквизит чека коррекции (тег 1192) не является unsigned int
+     * Номер ошибочного документа при печати чека коррекции (тег 1192)
+     * не является unsigned int (должен быть от 0 до 4,294,967,295)
      */
     public static final int ERROR_CODE_INVALID_FISCAL_SIGN_OF_INCORRECT_RECEIPT = -14;
 

--- a/src/main/java/ru/evotor/framework/kkt/FiscalTags.kt
+++ b/src/main/java/ru/evotor/framework/kkt/FiscalTags.kt
@@ -192,4 +192,10 @@ object FiscalTags {
      */
     const val MEASURE_CODE = 2108
 
+    /**
+     * фискальный признак ошибочного чека
+     * значение дополнительного реквизита.
+     */
+    const val FISCAL_SIGN_OF_INCORRECT_RECIEPT = 1192
+
 }

--- a/src/main/java/ru/evotor/framework/kkt/FiscalTags.kt
+++ b/src/main/java/ru/evotor/framework/kkt/FiscalTags.kt
@@ -196,6 +196,6 @@ object FiscalTags {
      * фискальный признак ошибочного чека
      * значение дополнительного реквизита.
      */
-    const val FISCAL_SIGN_OF_INCORRECT_RECIEPT = 1192
+    const val ADDITIONAL_REQUISITE_1192 = 1192
 
 }

--- a/src/main/java/ru/evotor/framework/kkt/FiscalTags.kt
+++ b/src/main/java/ru/evotor/framework/kkt/FiscalTags.kt
@@ -193,8 +193,7 @@ object FiscalTags {
     const val MEASURE_CODE = 2108
 
     /**
-     * фискальный признак ошибочного чека
-     * значение дополнительного реквизита.
+     * дополнительный реквизит чека
      */
     const val ADDITIONAL_REQUISITE_1192 = 1192
 


### PR DESCRIPTION
Добавлена возможность указывать дополнительный реквизит чека (тек 1192) коррекции через:
1. Настройки -> Обслуживание кассы -> Дополнительные операции -> Чек коррекции (OpenCorrection...ReceiptCommand)
2. Печать чека без использования UI (PrintCorrection...ReceiptComand)